### PR TITLE
Feat: Implement profanity filter for better language filtering

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@2toad/profanity": "^3.1.1",
     "@hookform/resolvers": "^3.10.0",
     "axios": "^1.7.9",
     "chart.js": "^4.4.7",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@2toad/profanity':
+        specifier: ^3.1.1
+        version: 3.1.1
       '@hookform/resolvers':
         specifier: ^3.10.0
         version: 3.10.0(react-hook-form@7.54.2(react@18.3.1))
@@ -107,6 +110,10 @@ importers:
         version: 5.4.8
 
 packages:
+
+  '@2toad/profanity@3.1.1':
+    resolution: {integrity: sha512-07ny4pCSa4gDrcJ4vZ/WWmiM90+8kv/clXfnDvThf9IJq0GldpjRVdzHCfMwGDs2Y/8eClmTGzKb5tEfUWy/uA==}
+    engines: {node: '>=12'}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -1656,6 +1663,8 @@ packages:
     resolution: {integrity: sha512-JED8pB50qbA4FOkDol0bYF/p60qSEDQqBD0/qeIrUCG1KbPBIQ776fCUNb9ldbPcSTxA69g/47XTo4TqWiuXOA==}
 
 snapshots:
+
+  '@2toad/profanity@3.1.1': {}
 
   '@alloc/quick-lru@5.2.0': {}
 

--- a/frontend/src/components/SingleNote.tsx
+++ b/frontend/src/components/SingleNote.tsx
@@ -7,8 +7,30 @@ import * as yup from 'yup';
 import { toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import Modal from './ui/Modal';
-import { noteSchema } from '../utils/validationSchemas';
+// import { noteSchema } from '../utils/validationSchemas';
 import { NoteProps } from '../interfaces/types';
+import { Profanity } from '@2toad/profanity';
+
+const profanity = new Profanity();
+
+// profanity.addWords([]); // Add Nepali profanity words
+
+// Validation schema
+const noteSchema = yup.object({
+  title: yup
+    .string()
+    .required('Title is required')
+    .test('no-profanity', 'Contains inappropriate language', (value) => {
+      return !profanity.exists(value || '');
+    }),
+  content: yup
+    .string()
+    .required('Content is required')
+    .test('no-profanity', 'Contains inappropriate language', (value) => {
+      return !profanity.exists(value || '');
+    }),
+  categories: yup.array().of(yup.string()),
+});
 
 type NoteFormData = yup.InferType<typeof noteSchema>;
 
@@ -165,7 +187,6 @@ const SingleNote: React.FC<SingleNoteProps> = ({
                         : ''
                     }`}
                     rows={field.rows}
-                    // maxLength={field.maxLength}
                   />
                 ) : (
                   <input
@@ -177,7 +198,6 @@ const SingleNote: React.FC<SingleNoteProps> = ({
                         ? 'border-red-500 placeholder:text-red-500'
                         : ''
                     }`}
-                    // maxLength={field.maxLength}
                   />
                 )}
               </div>


### PR DESCRIPTION
# Implement Profanity Filter for Note Creation (Closes Issue #22)

## Description
This PR introduces a profanity filter to the note creation process, addressing issue #22. Integrated the `@2toad/profanity` library to ensure that no vulgar, offensive, or inappropriate words are allowed when creating notes. This implementation enhances the user experience by maintaining a respectful and positive environment within the application.

## Attachments
![image](https://github.com/user-attachments/assets/c09fdf1f-9e3c-4951-91d2-84b561523a26)
